### PR TITLE
Make MinecraftStream use ArrayPool for async methods

### DIFF
--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -83,7 +83,7 @@ namespace Obsidian.Net
 
         public async Task<short> ReadShortAsync()
         {
-            var buffer = new byte[2];
+            using var buffer = new RentedArray<byte>(sizeof(short));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadInt16BigEndian(buffer);
         }
@@ -98,7 +98,7 @@ namespace Obsidian.Net
 
         public async Task<int> ReadIntAsync()
         {
-            var buffer = new byte[4];
+            using var buffer = new RentedArray<byte>(sizeof(int));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadInt32BigEndian(buffer);
         }
@@ -113,7 +113,7 @@ namespace Obsidian.Net
 
         public async Task<long> ReadLongAsync()
         {
-            var buffer = new byte[8];
+            using var buffer = new RentedArray<byte>(sizeof(long));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadInt64BigEndian(buffer);
         }
@@ -128,7 +128,7 @@ namespace Obsidian.Net
 
         public async Task<ulong> ReadUnsignedLongAsync()
         {
-            var buffer = new byte[8];
+            using var buffer = new RentedArray<byte>(sizeof(ulong));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadUInt64BigEndian(buffer);
         }
@@ -143,7 +143,7 @@ namespace Obsidian.Net
 
         public async Task<float> ReadFloatAsync()
         {
-            var buffer = new byte[4];
+            using var buffer = new RentedArray<byte>(sizeof(float));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadSingleBigEndian(buffer);
         }
@@ -158,7 +158,7 @@ namespace Obsidian.Net
 
         public async Task<double> ReadDoubleAsync()
         {
-            var buffer = new byte[8];
+            using var buffer = new RentedArray<byte>(sizeof(double));
             await this.ReadAsync(buffer);
             return BinaryPrimitives.ReadDoubleBigEndian(buffer);
         }
@@ -181,17 +181,17 @@ namespace Obsidian.Net
         public async Task<string> ReadStringAsync(int maxLength = 32767)
         {
             var length = await this.ReadVarIntAsync();
-            var buffer = new byte[length];
+            using var buffer = new RentedArray<byte>(length);
             if (BitConverter.IsLittleEndian)
             {
-                Array.Reverse(buffer);
+                buffer.Span.Reverse();
             }
-            await this.ReadAsync(buffer, 0, length);
+            await this.ReadAsync(buffer);
 
             var value = Encoding.UTF8.GetString(buffer);
             if (maxLength > 0 && value.Length > maxLength)
             {
-                throw new ArgumentException($"string ({value.Length}) exceeded maximum length ({maxLength})", nameof(value));
+                throw new ArgumentException($"string ({value.Length}) exceeded maximum length ({maxLength})", nameof(maxLength));
             }
             return value;
         }

--- a/Obsidian/Net/MinecraftStream.Writing.cs
+++ b/Obsidian/Net/MinecraftStream.Writing.cs
@@ -82,7 +82,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing unsigned Short ({value})");
 #endif
 
-            var write = new byte[sizeof(ushort)];
+            using var write = new RentedArray<byte>(sizeof(ushort));
             BinaryPrimitives.WriteUInt16BigEndian(write, value);
             await WriteAsync(write);
         }
@@ -101,7 +101,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Short ({value})");
 #endif
 
-            var write = new byte[sizeof(short)];
+            using var write = new RentedArray<byte>(sizeof(short));
             BinaryPrimitives.WriteInt16BigEndian(write, value);
             await WriteAsync(write);
         }
@@ -120,7 +120,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Int ({value})");
 #endif
 
-            var write = new byte[sizeof(int)];
+            using var write = new RentedArray<byte>(sizeof(int));
             BinaryPrimitives.WriteInt32BigEndian(write, value);
             await WriteAsync(write);
         }
@@ -139,7 +139,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Long ({value})");
 #endif
 
-            var write = new byte[sizeof(long)];
+            using var write = new RentedArray<byte>(sizeof(long));
             BinaryPrimitives.WriteInt64BigEndian(write, value);
             await WriteAsync(write);
         }
@@ -158,7 +158,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Float ({value})");
 #endif
 
-            var write = new byte[sizeof(float)];
+            using var write = new RentedArray<byte>(sizeof(float));
             BinaryPrimitives.WriteSingleBigEndian(write, value);
             await WriteAsync(write);
         }
@@ -177,7 +177,7 @@ namespace Obsidian.Net
             await Globals.PacketLogger.LogDebugAsync($"Writing Double ({value})");
 #endif
 
-            var write = new byte[sizeof(double)];
+            using var write = new RentedArray<byte>(sizeof(double));
             BinaryPrimitives.WriteDoubleBigEndian(write, value);
             await WriteAsync(write);
         }
@@ -187,7 +187,8 @@ namespace Obsidian.Net
         {
             System.Diagnostics.Debug.Assert(value.Length <= maxLength);
 
-            var bytes = Encoding.UTF8.GetBytes(value);
+            using var bytes = new RentedArray<byte>(Encoding.UTF8.GetByteCount(value));
+            Encoding.UTF8.GetBytes(value, bytes.Span);
             WriteVarInt(bytes.Length);
             Write(bytes);
         }
@@ -202,7 +203,8 @@ namespace Obsidian.Net
             if (value.Length > maxLength)
                 throw new ArgumentException($"string ({value.Length}) exceeded maximum length ({maxLength})", nameof(value));
 
-            var bytes = Encoding.UTF8.GetBytes(value);
+            using var bytes = new RentedArray<byte>(Encoding.UTF8.GetByteCount(value));
+            Encoding.UTF8.GetBytes(value, bytes.Span);
             await WriteVarIntAsync(bytes.Length);
             await WriteAsync(bytes);
         }

--- a/Obsidian/Utilities/RentedArray.cs
+++ b/Obsidian/Utilities/RentedArray.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Buffers;
+using System.Runtime.CompilerServices;
+
+namespace Obsidian.Utilities
+{
+    /// <summary>
+    /// An array rented from a <see cref="ArrayPool{T}"/> that will be returned upon dispose
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public readonly struct RentedArray<T> : IDisposable
+    {
+        /// <summary>
+        /// Number of <see cref="T"/> elements rented
+        /// </summary>
+        public int Length { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        private readonly ArrayPool<T> pool;
+        private readonly T[] array;
+
+        /// <summary>
+        /// A <see cref="System.Span{T}"/> representation of the array
+        /// </summary>
+        public Span<T> Span => array.AsSpan(0, Length);
+        
+        /// <summary>
+        /// A <see cref="System.Memory{T}"/> representation of the array
+        /// </summary>
+        public Memory<T> Memory => array.AsMemory(0, Length);
+
+        public RentedArray(int length, ArrayPool<T>? pool = null)
+        {
+            this.pool = pool ?? ArrayPool<T>.Shared;
+            array = this.pool.Rent(length);
+            Length = length;
+        }
+        
+
+        /// <summary>
+        /// Returns the rented array to the pool
+        /// </summary>
+        public void Dispose() => pool.Return(array);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Span<T>(in RentedArray<T> rentedArray) => rentedArray.Span;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator ReadOnlySpan<T>(in RentedArray<T> rentedArray) => rentedArray.Span;
+        
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Memory<T>(in RentedArray<T> rentedArray) => rentedArray.Memory;
+        
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator ReadOnlyMemory<T>(in RentedArray<T> rentedArray) => rentedArray.Memory;
+    }
+}


### PR DESCRIPTION
Though this can help with the GC pressure, because is using the Shared array pool it can end up using a lot of memory if there is a lot of traffic.

This could be solved by making each Client past the Status state have it's own ArrayPool.