### PR TITLE
Properly use Logger

### DIFF
--- a/Obsidian/Client.cs
+++ b/Obsidian/Client.cs
@@ -340,7 +340,7 @@ public sealed class Client : IDisposable
             }
         }
 
-        Logger.LogInformation($"Disconnected client");
+        Logger.LogInformation("Disconnected client");
 
         if (State == ClientState.Play)
         {
@@ -603,7 +603,7 @@ public sealed class Client : IDisposable
     {
         if (!missedKeepAlives.Contains(keepAlive.KeepAliveId))
         {
-            Logger.LogWarning($"Received invalid KeepAlive from {Player.Username}?? Naughty???? ({Player.Uuid})");
+            Logger.LogWarning("Received invalid KeepAlive from {Username}?? Naughty???? ({Uuid})", Player?.Username, Player?.Uuid);
             await DisconnectAsync(ChatMessage.Simple("Kicked for invalid KeepAlive."));
             return;
         }
@@ -614,7 +614,7 @@ public sealed class Client : IDisposable
         ping = Math.Max(0, ping); // negative ping is impossible.
 
         this.ping = (int)ping;
-        Logger.LogDebug($"Valid KeepAlive ({keepAlive.KeepAliveId}) handled from {Player.Username} ({Player.Uuid})");
+        Logger.LogDebug("Valid KeepAlive ({KeepAliveId}) handled from {Username} ({Uuid})", keepAlive.KeepAliveId, Player?.Username, Player?.Uuid);
         // KeepAlive is handled.
         missedKeepAlives.Remove(keepAlive.KeepAliveId);
     }

--- a/Obsidian/Net/MinecraftStream.Reading.cs
+++ b/Obsidian/Net/MinecraftStream.Reading.cs
@@ -622,7 +622,7 @@ public partial class MinecraftStream
                                 {
                                     var enchantments = (NbtList)child;
 
-                                    //Globals.PacketLogger.LogDebug($"List Type: {enchantments.ListType}");
+                                    //Globals.PacketLogger.LogDebug("List Type: {ListType}", enchantments.ListType);
 
                                     foreach (var enchantment in enchantments)
                                     {
@@ -651,7 +651,7 @@ public partial class MinecraftStream
                                     var intTag = (NbtTag<int>)child;
 
                                     itemMetaBuilder.WithDurability(intTag.Value);
-                                    //Globals.PacketLogger.LogDebug($"Setting damage: {tag.IntValue}");
+                                    //Globals.PacketLogger.LogDebug("Setting damage: {IntValue}", tag.IntValue);
                                     break;
                                 }
 
@@ -733,7 +733,7 @@ public partial class MinecraftStream
                                 {
                                     var enchantments = (NbtList)child;
 
-                                    //Globals.PacketLogger.LogDebug($"List Type: {enchantments.ListType}");
+                                    //Globals.PacketLogger.LogDebug("List Type: {ListType}", enchantments.ListType);
 
                                     foreach (var enchantment in enchantments)
                                     {
@@ -761,7 +761,7 @@ public partial class MinecraftStream
                                     var intTag = (NbtTag<int>)child;
 
                                     itemMetaBuilder.WithDurability(intTag.Value);
-                                    //Globals.PacketLogger.LogDebug($"Setting damage: {tag.IntValue}");
+                                    //Globals.PacketLogger.LogDebug("Setting damage: {IntValue}", tag.IntValue);
                                     break;
                                 }
                             case "display":

--- a/Obsidian/Net/MinecraftStream.cs
+++ b/Obsidian/Net/MinecraftStream.cs
@@ -65,7 +65,7 @@ public partial class MinecraftStream : Stream
         if (clear)
             await ClearDebug();
 
-        //Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
+        //Globals.PacketLogger.LogDebug("Dumped stream to {FilePath}", filePath);
     }
 
     // unused
@@ -83,7 +83,7 @@ public partial class MinecraftStream : Stream
         if (clear)
             await ClearDebug();
 
-        //Globals.PacketLogger.LogDebug($"Dumped stream to {filePath}");
+        //Globals.PacketLogger.LogDebug("Dumped stream to {FilePath}", filePath);
     }
 
     public Task ClearDebug()

--- a/Obsidian/Plugins/PluginProviders/RemotePluginProvider.cs
+++ b/Obsidian/Plugins/PluginProviders/RemotePluginProvider.cs
@@ -122,7 +122,7 @@ public class RemotePluginProvider : IPluginProvider
                     if (diagnostic.Severity != DiagnosticSeverity.Error || diagnostic.IsWarningAsError)
                         continue;
 
-                    logger.LogError($"Compilation failed: {diagnostic.Location} {diagnostic.GetMessage()}");
+                    logger.LogError("Compilation failed: {Location} {Message}", diagnostic.Location, diagnostic.GetMessage());
                 }
             }
 

--- a/Obsidian/Plugins/PluginProviders/UncompiledPluginProvider.cs
+++ b/Obsidian/Plugins/PluginProviders/UncompiledPluginProvider.cs
@@ -48,7 +48,7 @@ public class UncompiledPluginProvider : IPluginProvider
         }
         catch
         {
-            logger.LogError($"Reloading '{Path.GetFileName(path)}' failed, file is not accessible.");
+            logger.LogError("Reloading '{Path}' failed, file is not accessible.", Path.GetFileName(path));
             return new PluginContainer(new PluginInfo(name), name);
         }
         SyntaxTree syntaxTree = CSharpSyntaxTree.ParseText(SourceText.From(fileStream));
@@ -69,7 +69,7 @@ public class UncompiledPluginProvider : IPluginProvider
                     if (diagnostic.Severity != DiagnosticSeverity.Error || diagnostic.IsWarningAsError)
                         continue;
 
-                    logger.LogError($"Compilation failed: {diagnostic.Location} {diagnostic.GetMessage()}");
+                    logger.LogError("Compilation failed: {Location} {Message}", diagnostic.Location, diagnostic.GetMessage());
                 }
             }
 

--- a/Obsidian/Server.cs
+++ b/Obsidian/Server.cs
@@ -253,7 +253,7 @@ public sealed partial class Server : IServer
 
         await this.userCache.LoadAsync(this._cancelTokenSource.Token);
 
-        _logger.LogInformation($"Loading properties...");
+        _logger.LogInformation("Loading properties...");
 
         await (Operators as OperatorList).InitializeAsync();
 
@@ -267,7 +267,7 @@ public sealed partial class Server : IServer
         await Task.WhenAll(Configuration.DownloadPlugins.Select(path => PluginManager.LoadPluginAsync(path)));
 
         if (!Configuration.OnlineMode)
-            _logger.LogInformation($"Starting in offline mode...");
+            _logger.LogInformation("Starting in offline mode...");
 
         CommandsRegistry.Register(this);
 

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -457,7 +457,7 @@ public sealed class World : IWorld
         if (levelCompound.TryGetTag("Version", out var tag))
             LevelData.VersionData = tag as NbtCompound;
 
-        Logger.LogInformation($"Loading spawn chunks into memory...");
+        Logger.LogInformation("Loading spawn chunks into memory...");
         for (int rx = -1; rx < 1; rx++)
             for (int rz = -1; rz < 1; rz++)
                 LoadRegion(rx, rz);


### PR DESCRIPTION
Closes #394

I didnt touch `Console.WriteLine`, and `Obsidian/Obsidian/Net/MinecraftStream.Writing.cs` because it uses `Globals.PacketLogger`, which doesnt exist. I did do comments with `Globals.PacketLogger`, because someone might copy/paste from those. IDK what i was thinking.

I used a RegEx i built to find all of these "wrong" usages: `Log(ger)?\.[a-zA-z]{1,16}\(\$"`