### PR TITLE
Worldgen savings

### DIFF
--- a/Obsidian.API/ChunkData/DataContainer.cs
+++ b/Obsidian.API/ChunkData/DataContainer.cs
@@ -14,7 +14,7 @@ public abstract class DataContainer<T>
 
     public abstract IPalette<T> Palette { get; internal set; }
 
-    internal virtual DataArray DataArray { get; private protected set; }
+    internal virtual DataArray? DataArray { get; private protected set; }
 
     public virtual int GetIndex(int x, int y, int z) => (y << this.BitsPerEntry | z) << this.BitsPerEntry | x;
 

--- a/Obsidian.API/ChunkData/DataContainer.cs
+++ b/Obsidian.API/ChunkData/DataContainer.cs
@@ -1,16 +1,34 @@
 ﻿using Obsidian.API.Utilities;
+using System.Threading;
 
 namespace Obsidian.API.ChunkData;
+
 public abstract class DataContainer<T>
 {
-    public bool IsEmpty { get; }
-    public byte BitsPerEntry => (byte)DataArray.BitsPerEntry;
+    private readonly Lock storageLock = new();
+
+    public int EntryCount { get; protected set; }
+
+    public virtual bool IsEmpty { get; }
+    public byte BitsPerEntry => (byte)this.Palette.BitCount;
 
     public abstract IPalette<T> Palette { get; internal set; }
 
-    internal abstract DataArray DataArray { get; private protected set; }
+    internal virtual DataArray DataArray { get; private protected set; }
 
     public virtual int GetIndex(int x, int y, int z) => (y << this.BitsPerEntry | z) << this.BitsPerEntry | x;
+
+    public DataContainer(int entryCount, IPalette<T> palette)
+    {
+        this.EntryCount = entryCount;
+        this.Palette = palette;
+        this.DataArray = BitsPerEntry != 0 ? new DataArray(BitsPerEntry, entryCount) : null;
+    }
+
+    public DataContainer(int entryCount, IPalette<T> palette, T defaultValue) : this(entryCount, palette)
+    {
+        this.Palette.GetOrAddId(defaultValue);
+    }
 
     public void GrowDataArray()
     {
@@ -20,11 +38,56 @@ public abstract class DataContainer<T>
         DataArray = DataArray.Grow(Palette.BitCount);
     }
 
-    public abstract void Set(int x, int y, int z, T blockState);
+    public void InitializeDataArray()
+    {
+        if (this.Palette.BitCount == 0)
+            return;
 
-    public abstract T Get(int x, int y, int z);
+        this.DataArray = new DataArray(this.Palette.BitCount, this.EntryCount);
+    }
 
-    public abstract void WriteTo(INetStreamWriter writer);
+    public virtual void Set(int x, int y, int z, T blockState)
+    {
+        lock (this.storageLock)
+        {
+            var blockIndex = GetIndex(x, y, z);
+
+            int paletteId = Palette.GetOrAddId(blockState);
+
+            if (this.Palette.BitCount == 0)
+                return;
+
+            DataArray ??= new DataArray(this.Palette.BitCount, this.EntryCount);
+
+            this.GrowDataArray();
+
+            DataArray[blockIndex] = paletteId;
+        }
+    }
+
+    public virtual T Get(int x, int y, int z)
+    {
+        lock (this.storageLock)
+        {
+            if (this.Palette.BitCount == 0)
+                return Palette.GetValueFromIndex(0);
+
+            var index = GetIndex(x, y, z);
+            int storageId = DataArray[index];
+
+            return Palette.GetValueFromIndex(storageId);
+        }
+    }
+
+    public virtual void WriteTo(INetStreamWriter writer)
+    {
+        writer.WriteByte(this.BitsPerEntry);
+
+        this.Palette.WriteTo(writer);
+
+        if (this.DataArray != null)
+            writer.WriteLongArray(this.DataArray.storage);
+    }
 
     public abstract DataContainer<T> Clone();
 }

--- a/Obsidian.API/ChunkData/Palettes/BaseIndirectPalette.cs
+++ b/Obsidian.API/ChunkData/Palettes/BaseIndirectPalette.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace Obsidian.ChunkData;
+namespace Obsidian.API.ChunkData.Palettes;
 
 public abstract class BaseIndirectPalette<T> : IPalette<T>
 {
@@ -81,9 +81,15 @@ public abstract class BaseIndirectPalette<T> : IPalette<T>
 
     public void WriteTo(INetStreamWriter writer)
     {
-        writer.WriteVarInt(Count);
-
         ReadOnlySpan<int> values = GetSpan();
+
+        if (this.BitCount == 0)
+        {
+            writer.WriteVarInt(values[0]);
+            return;
+        }
+
+        writer.WriteVarInt(Count);
 
         for (int i = 0; i < values.Length; ++i)
             writer.WriteVarInt(values[i]);
@@ -95,3 +101,4 @@ public abstract class BaseIndirectPalette<T> : IPalette<T>
         return MemoryMarshal.CreateReadOnlySpan(ref first, Count);
     }
 }
+

--- a/Obsidian.API/_Enums/HeightmapType.cs
+++ b/Obsidian.API/_Enums/HeightmapType.cs
@@ -4,9 +4,9 @@ public enum HeightmapType : int
     WorldSurfaceWG,
     WorldSurface,
 
-    OceanFloorWG,
-    OceanFloor,
+    //OceanFloorWG,
+    //OceanFloor,
 
     MotionBlocking,
-    MotionBlockingNoLeaves,
+    //MotionBlockingNoLeaves,
 }

--- a/Obsidian/ChunkData/BiomeContainer.cs
+++ b/Obsidian/ChunkData/BiomeContainer.cs
@@ -6,34 +6,12 @@ public sealed class BiomeContainer : DataContainer<Biome>
 
     internal override DataArray DataArray { get; private protected set; }
 
-    internal BiomeContainer(byte bitsPerEntry = 2)
-    {
-        this.Palette = bitsPerEntry.DetermineBiomePalette();
-        this.DataArray = new(bitsPerEntry, 64);
-    }
+    internal BiomeContainer(byte bitsPerEntry = 0) : base(64, bitsPerEntry.DetermineBiomePalette(), Biome.Plains) { }
 
-    private BiomeContainer(IPalette<Biome> palette, DataArray dataArray)
+    private BiomeContainer(IPalette<Biome> palette, DataArray dataArray) : base(64, palette)
     {
         Palette = palette;
         DataArray = dataArray;
-    }
-
-    public override void Set(int x, int y, int z, Biome biome)
-    {
-        var index = this.GetIndex(x, y, z);
-
-        var paletteIndex = this.Palette.GetOrAddId(biome);
-
-        this.GrowDataArray();
-
-        this.DataArray[index] = paletteIndex;
-    }
-
-    public override Biome Get(int x, int y, int z)
-    {
-        var storageId = this.DataArray[this.GetIndex(x, y, z)];
-
-        return this.Palette.GetValueFromIndex(storageId);
     }
 
     public override void WriteTo(INetStreamWriter writer)

--- a/Obsidian/ChunkData/BlockStateContainer.cs
+++ b/Obsidian/ChunkData/BlockStateContainer.cs
@@ -4,77 +4,31 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
 {
     public override IPalette<IBlock> Palette { get; internal set; }
 
-    public bool IsEmpty => DataArray.storage.Length == 0;
+    public override bool IsEmpty => DataArray.storage.Length == 0;
 
-    internal override DataArray DataArray { get; private protected set; }
+    internal BlockStateContainer(byte bitsPerEntry = 0) : base(4096, bitsPerEntry.DetermineBlockPalette(), BlocksRegistry.Air) { }
 
-
-#if CACHE_VALID_BLOCKS
-    private readonly DirtyCache<short> validBlockCount;
-#endif
-
-    internal BlockStateContainer(byte bitsPerEntry = 4)
-    {
-        DataArray = new DataArray(bitsPerEntry, 4096);
-        Palette = bitsPerEntry.DetermineBlockPalette();
-
-#if CACHE_VALID_BLOCKS
-        validBlockCount = new(GetNonAirBlocks);
-#endif
-    }
-
-    private BlockStateContainer(IPalette<IBlock> palette, DataArray dataArray)
+    private BlockStateContainer(IPalette<IBlock> palette, DataArray dataArray) : base(4096, palette)
     {
         Palette = palette;
         DataArray = dataArray;
-
-#if CACHE_VALID_BLOCKS
-        validBlockCount = new(GetNonAirBlocks);
-#endif
-    }
-
-    public override void Set(int x, int y, int z, IBlock blockState)
-    {
-#if CACHE_VALID_BLOCKS
-        validBlockCount.SetDirty();
-#endif
-        var blockIndex = GetIndex(x, y, z);
-
-        int paletteId = Palette.GetOrAddId(blockState);
-
-        this.GrowDataArray();
-
-        DataArray[blockIndex] = paletteId;
-    }
-
-    public override IBlock Get(int x, int y, int z)
-    {
-        int storageId = DataArray[GetIndex(x, y, z)];
-
-        return Palette.GetValueFromIndex(storageId);
     }
 
     public override void WriteTo(INetStreamWriter writer)
     {
-#if CACHE_VALID_BLOCKS
-        var validBlocks = validBlockCount.GetValue();
-#else
         var validBlocks = GetNonAirBlocks();
-#endif
 
         writer.WriteShort(validBlocks);
         writer.WriteByte(BitsPerEntry);
 
         Palette.WriteTo(writer);
 
-        writer.WriteLongArray(DataArray.storage);
+        if (this.DataArray != null)
+            writer.WriteLongArray(DataArray.storage);
     }
 
     public void Fill(IBlock block)
     {
-#if CACHE_VALID_BLOCKS
-        validBlockCount.SetDirty();
-#endif
         int index = Palette.GetOrAddId(block);
         for (int i = 0; i < 16 * 16 * 16; i++)
         {

--- a/Obsidian/ChunkData/BlockStateContainer.cs
+++ b/Obsidian/ChunkData/BlockStateContainer.cs
@@ -27,15 +27,6 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
             writer.WriteLongArray(DataArray.storage);
     }
 
-    public void Fill(IBlock block)
-    {
-        int index = Palette.GetOrAddId(block);
-        for (int i = 0; i < 16 * 16 * 16; i++)
-        {
-            DataArray[i] = index;
-        }
-    }
-
     private short GetNonAirBlocks()
     {
         int validBlocksCount = 0;

--- a/Obsidian/ChunkData/BlockStateContainer.cs
+++ b/Obsidian/ChunkData/BlockStateContainer.cs
@@ -2,13 +2,14 @@
 
 public sealed class BlockStateContainer : DataContainer<IBlock>
 {
+    private const int MaxEntryCount = 4096;
     public override IPalette<IBlock> Palette { get; internal set; }
 
-    public override bool IsEmpty => DataArray.storage.Length == 0;
+    public override bool IsEmpty => this.Palette.Count == 0;
 
-    internal BlockStateContainer(byte bitsPerEntry = 0) : base(4096, bitsPerEntry.DetermineBlockPalette(), BlocksRegistry.Air) { }
+    internal BlockStateContainer(byte bitsPerEntry = 0) : base(MaxEntryCount, bitsPerEntry.DetermineBlockPalette(), BlocksRegistry.Air) { }
 
-    private BlockStateContainer(IPalette<IBlock> palette, DataArray dataArray) : base(4096, palette)
+    private BlockStateContainer(IPalette<IBlock> palette, DataArray dataArray) : base(MaxEntryCount, palette)
     {
         Palette = palette;
         DataArray = dataArray;
@@ -39,7 +40,7 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
             goto TWO_INDEXES;
 
         // 1 1 1
-        for (int i = 0; i < 16 * 16 * 16; i++)
+        for (int i = 0; i < MaxEntryCount; i++)
         {
             int index = DataArray[i];
             if (index != indexOne && index != indexTwo && index != indexThree)
@@ -69,7 +70,7 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
 
         // 1 0 0
         ONE_INDEX:
-        for (int i = 0; i < 16 * 16 * 16; i++)
+        for (int i = 0; i < MaxEntryCount; i++)
         {
             int index = DataArray[i];
             if (index != indexOne)
@@ -79,7 +80,7 @@ public sealed class BlockStateContainer : DataContainer<IBlock>
 
     // 1 1 0
     TWO_INDEXES:
-        for (int i = 0; i < 16 * 16 * 16; i++)
+        for (int i = 0; i < MaxEntryCount; i++)
         {
             int index = DataArray[i];
             if (index != indexOne && index != indexTwo)

--- a/Obsidian/ChunkData/ChunkSection.cs
+++ b/Obsidian/ChunkData/ChunkSection.cs
@@ -21,7 +21,7 @@ public sealed class ChunkSection : IChunkSection
 
     private byte[] blockLight = new byte[2048];
 
-    public ChunkSection(byte bitsPerBlock = 4, byte bitsPerBiome = 2, int? yBase = null)
+    public ChunkSection(byte bitsPerBlock = 0, byte bitsPerBiome = 0, int? yBase = null)
     {
         this.BlockStateContainer = new BlockStateContainer(bitsPerBlock);
         this.BiomeContainer = new BiomeContainer(bitsPerBiome);

--- a/Obsidian/ChunkData/DataContainer.cs
+++ b/Obsidian/ChunkData/DataContainer.cs
@@ -1,1 +1,0 @@
-﻿namespace Obsidian.ChunkData;

--- a/Obsidian/ChunkData/GlobalBiomePalette.cs
+++ b/Obsidian/ChunkData/GlobalBiomePalette.cs
@@ -3,14 +3,9 @@
 public class GlobalBiomePalette : IPalette<Biome>
 {
     public int[] Values => throw new NotSupportedException();
-    public int BitCount { get; }
+    public int BitCount { get; } = CodecRegistry.Biomes.GlobalBitsPerEntry;
     public int Count => throw new NotSupportedException();
     public bool IsFull => false;
-
-    public GlobalBiomePalette(int bitCount)
-    {
-        this.BitCount = bitCount;
-    }
 
     public bool TryGetId(Biome biome, out int id)
     {

--- a/Obsidian/ChunkData/GlobalBlockStatePalette.cs
+++ b/Obsidian/ChunkData/GlobalBlockStatePalette.cs
@@ -1,20 +1,12 @@
-﻿using Obsidian.Net;
-using Obsidian.Registries;
+﻿namespace Obsidian.ChunkData;
 
-namespace Obsidian.ChunkData;
-
-public class GlobalBlockStatePalette : IPalette<IBlock>
+public class GlobalBlockStatePalette() : IPalette<IBlock>
 {
     public int[] Values => throw new NotSupportedException();
-    public int BitCount { get; }
+    public int BitCount { get; } = 15;
     public int Count => throw new NotSupportedException();
 
     public bool IsFull => false;
-
-    public GlobalBlockStatePalette(int bitCount)
-    {
-        this.BitCount = bitCount;
-    }
 
     public bool TryGetId(IBlock block, out int id)
     {

--- a/Obsidian/ChunkData/Heightmap.cs
+++ b/Obsidian/ChunkData/Heightmap.cs
@@ -1,6 +1,0 @@
-﻿using Obsidian.Utilities.Collections;
-using Obsidian.WorldData;
-
-namespace Obsidian.ChunkData;
-
-//TODO make better impl of heightmaps

--- a/Obsidian/ChunkData/IndirectPalette.cs
+++ b/Obsidian/ChunkData/IndirectPalette.cs
@@ -1,8 +1,9 @@
-﻿using Obsidian.Exceptions;
+﻿using Obsidian.API.ChunkData.Palettes;
+using Obsidian.Exceptions;
 
 namespace Obsidian.ChunkData;
 
-public sealed class IndirectPalette : BaseIndirectPalette<IBlock>, IPalette<IBlock>
+public sealed class IndirectPalette : BaseIndirectPalette<IBlock>
 {
     public IndirectPalette(byte bitCount) : base(bitCount)
     {

--- a/Obsidian/ChunkData/InternalIndirectPalette.cs
+++ b/Obsidian/ChunkData/InternalIndirectPalette.cs
@@ -1,7 +1,9 @@
-﻿using System.Runtime.CompilerServices;
+﻿using Obsidian.API.ChunkData.Palettes;
+using System.Runtime.CompilerServices;
 
 namespace Obsidian.ChunkData;
-internal sealed class InternalIndirectPalette<T> : BaseIndirectPalette<T>, IPalette<T> where T : struct
+
+internal sealed class InternalIndirectPalette<T> : BaseIndirectPalette<T> where T : struct
 {
     public InternalIndirectPalette(byte bitCount) : base(bitCount)
     {

--- a/Obsidian/ChunkData/Palette.cs
+++ b/Obsidian/ChunkData/Palette.cs
@@ -1,6 +1,4 @@
-﻿using Obsidian.Registries;
-
-namespace Obsidian.ChunkData;
+﻿namespace Obsidian.ChunkData;
 
 public static class Palette
 {
@@ -8,17 +6,17 @@ public static class Palette
     {
         return bitsPerEntry switch
         {
+            0 => new IndirectPalette(0),
             <= 4 => new IndirectPalette(4),
             > 4 and <= 8 => new IndirectPalette(bitsPerEntry),
-            _ => new GlobalBlockStatePalette(BlocksRegistry.GlobalBitsPerBlocks)
+            _ => new GlobalBlockStatePalette()
         };
     }
 
     public static IPalette<Biome> DetermineBiomePalette(this byte bitsPerEntry)
     {
-        if (bitsPerEntry <= 3)
-            return new InternalIndirectPalette<Biome>(bitsPerEntry);
-
-        return new GlobalBiomePalette(CodecRegistry.Biomes.GlobalBitsPerEntry);
+        return bitsPerEntry <= 3
+            ? new InternalIndirectPalette<Biome>(bitsPerEntry)
+            : new GlobalBiomePalette();
     }
 }

--- a/Obsidian/Net/Packets/Play/Clientbound/LevelChunkWithLightPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/LevelChunkWithLightPacket.cs
@@ -30,7 +30,7 @@ public partial class LevelChunkWithLightPacket(IChunk chunk)
             }
         }
 
-        writer.WriteVarInt((int)sectionBuffer.Size);
+        writer.WriteVarInt(sectionBuffer.Size);
         writer.Write(sectionBuffer);
 
 

--- a/Obsidian/Net/Packets/Play/Clientbound/LevelChunkWithLightPacket.cs
+++ b/Obsidian/Net/Packets/Play/Clientbound/LevelChunkWithLightPacket.cs
@@ -11,22 +11,13 @@ public partial class LevelChunkWithLightPacket(IChunk chunk)
         writer.WriteInt(Chunk.X);
         writer.WriteInt(Chunk.Z);
 
-        //Chunk.CalculateHeightmap();
-
+        //Heightmap writing we're only sending motion blocking for now.
         writer.WriteVarInt(1);
-        foreach (var (type, heightmap) in Chunk.Heightmaps)
-            if (type == HeightmapType.MotionBlocking)
-            {
-                var dataArray = heightmap.GetDataArray();
+        var heightmap = Chunk.Heightmaps[HeightmapType.MotionBlocking];
+        var heightmapStorage = heightmap.GetDataArray();
 
-                writer.WriteVarInt(type.GetHashCode());
-                writer.WriteVarInt(dataArray.Length);
-
-                foreach(var height in dataArray)
-                    writer.WriteLong(height);
-
-                break;
-            }
+        writer.WriteVarInt(HeightmapType.MotionBlocking.GetHashCode());
+        writer.WriteLengthPrefixedArray(writer.WriteLong, heightmapStorage);
 
         var sectionBuffer = new NetworkBuffer();
 

--- a/Obsidian/WorldData/Chunk.cs
+++ b/Obsidian/WorldData/Chunk.cs
@@ -28,7 +28,7 @@ public sealed class Chunk : IChunk
         {
             { HeightmapType.MotionBlocking, new Heightmap(HeightmapType.MotionBlocking, this) },
             //{ HeightmapType.OceanFloor, new Heightmap(HeightmapType.OceanFloor, this) },
-            //{ HeightmapType.WorldSurface, new Heightmap(HeightmapType.WorldSurface, this) },
+            { HeightmapType.WorldSurface, new Heightmap(HeightmapType.WorldSurface, this) },
             { HeightmapType.WorldSurfaceWG, new Heightmap(HeightmapType.WorldSurfaceWG, this) },
             //{ HeightmapType.MotionBlockingNoLeaves, new Heightmap(HeightmapType.MotionBlockingNoLeaves, this) }
         };

--- a/Obsidian/WorldData/Chunk.cs
+++ b/Obsidian/WorldData/Chunk.cs
@@ -12,10 +12,6 @@ public sealed class Chunk : IChunk
 
     public ChunkGenStage ChunkStatus { get; private set; } = ChunkGenStage.empty;
 
-    private const int width = 16;
-    private const int worldHeight = 320;
-    private const int worldFloor = -64;
-
     //TODO try and do some temp caching
     public Dictionary<short, BlockMeta> BlockMetaStore { get; private set; } = new Dictionary<short, BlockMeta>();
     public Dictionary<short, IBlockEntity> BlockEntities { get; private set; } = new Dictionary<short, IBlockEntity>();
@@ -31,10 +27,10 @@ public sealed class Chunk : IChunk
         Heightmaps = new Dictionary<HeightmapType, Heightmap>()
         {
             { HeightmapType.MotionBlocking, new Heightmap(HeightmapType.MotionBlocking, this) },
-            { HeightmapType.OceanFloor, new Heightmap(HeightmapType.OceanFloor, this) },
-            { HeightmapType.WorldSurface, new Heightmap(HeightmapType.WorldSurface, this) },
+            //{ HeightmapType.OceanFloor, new Heightmap(HeightmapType.OceanFloor, this) },
+            //{ HeightmapType.WorldSurface, new Heightmap(HeightmapType.WorldSurface, this) },
             { HeightmapType.WorldSurfaceWG, new Heightmap(HeightmapType.WorldSurfaceWG, this) },
-            { HeightmapType.MotionBlockingNoLeaves, new Heightmap(HeightmapType.MotionBlockingNoLeaves, this) }
+            //{ HeightmapType.MotionBlockingNoLeaves, new Heightmap(HeightmapType.MotionBlockingNoLeaves, this) }
         };
 
         Sections = new ChunkSection[24];
@@ -153,26 +149,6 @@ public sealed class Chunk : IChunk
         y = NumericsHelper.Modulo(y, 16);
         z = NumericsHelper.Modulo(z, 16);
         return sec.GetLightLevel(x, y, z, lt);
-    }
-
-    public void CalculateHeightmap()
-    {
-        Heightmap target = Heightmaps[HeightmapType.MotionBlocking];
-        for (int x = 0; x < width; x++)
-        {
-            for (int z = 0; z < width; z++)
-            {
-                for (int y = worldHeight - 1; y >= worldFloor; y--)
-                {
-                    var block = GetBlock(x, y, z);
-                    if (block.Material == Material.Air)
-                        continue;
-
-                    target.Set(x, z, value: y);
-                    break;
-                }
-            }
-        }
     }
 
     public void WriteLightMaskTo(INetStreamWriter writer, LightType lt)

--- a/Obsidian/WorldData/Chunk.cs
+++ b/Obsidian/WorldData/Chunk.cs
@@ -40,7 +40,7 @@ public sealed class Chunk : IChunk
         Sections = new ChunkSection[24];
         for (int i = 0; i < Sections.Length; i++)
         {
-            Sections[i] = new ChunkSection(4, yBase: i - 4);
+            Sections[i] = new ChunkSection(yBase: i - 4);
         }
 
 

--- a/Obsidian/WorldData/Generators/Overworld/ChunkBuilder.cs
+++ b/Obsidian/WorldData/Generators/Overworld/ChunkBuilder.cs
@@ -284,7 +284,7 @@ internal static class ChunkBuilder
                 bool worldSurfaceSet = false;
                 bool motionBlockingSet = false;
                 bool motionBlockingLeavesSet = false;
-                chunk.Heightmaps[HeightmapType.OceanFloor] = chunk.Heightmaps[HeightmapType.WorldSurfaceWG];
+                //chunk.Heightmaps[HeightmapType.OceanFloor] = chunk.Heightmaps[HeightmapType.WorldSurfaceWG];
 
                 for (int y = 319; y >= -64; y--)
                 {
@@ -323,7 +323,7 @@ internal static class ChunkBuilder
                         !TagsRegistry.Block.Leaves.Entries.Contains(b.RegistryId)
                         )
                     {
-                        chunk.Heightmaps[HeightmapType.MotionBlockingNoLeaves].Set(x, z, y);
+                        //chunk.Heightmaps[HeightmapType.MotionBlockingNoLeaves].Set(x, z, y);
                         motionBlockingLeavesSet = true;
                     }
 

--- a/Obsidian/WorldData/Region.cs
+++ b/Obsidian/WorldData/Region.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Logging;
+using Obsidian.API.ChunkData.Palettes;
 using Obsidian.ChunkData;
 using Obsidian.Nbt;
 using Obsidian.Utilities.Collections;
@@ -183,17 +184,17 @@ public class Region : IRegion
             if (statesCompound!.TryGetTag("palette", out var palleteArrayTag))
             {
                 var blockStatesPalette = palleteArrayTag as NbtList;
-                foreach (NbtCompound entry in blockStatesPalette!)
+                foreach (NbtCompound entry in blockStatesPalette!.Cast<NbtCompound>())
                 {
                     var id = entry.GetInt("Id");
                     chunkSecPalette.GetOrAddId(BlocksRegistry.Get(id));//TODO PROCESS ADDED PROPERTIES TO GET CORRECT BLOCK STATE
                 }
-
-                section.BlockStateContainer.GrowDataArray();
             }
 
             if (statesCompound.TryGetTag("data", out var dataArrayTag))
             {
+                section.BlockStateContainer.InitializeDataArray();
+
                 var data = dataArrayTag as NbtArray<long>;
                 section.BlockStateContainer.DataArray.storage = data!.GetArray();
             }
@@ -207,12 +208,12 @@ public class Region : IRegion
                     if (Enum.TryParse<Biome>(biome.Value.TrimResourceTag(), true, out var value))
                         biomePalette.GetOrAddId(value);
                 }
-
-                section.BiomeContainer.GrowDataArray();
             }
 
             if (biomesCompound.TryGetTag("data", out var biomeDataArrayTag))
             {
+                section.BiomeContainer.InitializeDataArray();
+
                 var data = biomeDataArrayTag as NbtArray<long>;
                 section.BiomeContainer.DataArray.storage = data!.GetArray();
             }
@@ -285,7 +286,8 @@ public class Region : IRegion
 
                 writer.EndList();
 
-                writer.WriteArray("data", section.BlockStateContainer.DataArray.storage);
+                if (section.BlockStateContainer.DataArray is not null)
+                    writer.WriteArray("data", section.BlockStateContainer.DataArray.storage);
             }
 
             writer.EndCompound();
@@ -305,7 +307,7 @@ public class Region : IRegion
 
                 writer.EndList();
 
-                if (indirectBiomePalette.Values.Length > 1)
+                if (section.BiomeContainer.DataArray is not null)
                     writer.WriteArray("data", section.BiomeContainer.DataArray.storage);
             }
 

--- a/Obsidian/WorldData/World.cs
+++ b/Obsidian/WorldData/World.cs
@@ -178,8 +178,7 @@ public sealed partial class World : IWorld
     public async ValueTask<int?> GetWorldSurfaceHeightAsync(int x, int z)
     {
         var c = await GetChunkAsync(x.ToChunkCoord(), z.ToChunkCoord(), false);
-        return c?.Heightmaps[HeightmapType.WorldSurface]
-        .GetHeight(NumericsHelper.Modulo(x, 16), NumericsHelper.Modulo(z, 16));
+        return c?.Heightmaps[HeightmapType.WorldSurface].GetHeight(NumericsHelper.Modulo(x, 16), NumericsHelper.Modulo(z, 16));
     }
 
     public async ValueTask SetBlockAsync(int x, int y, int z, IBlock block)


### PR DESCRIPTION
This pr is for trying to get as much memory savings as possible. There were a lot of things with unused data arrays. 
Added single value palettes for chunk sections that just consist of 1 block this makes for some more crazy savings. I believe this can be pushed a bit further but as of right now I'll put it on the backburner for when I finish the worldgen-api rework 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved thread-safety for chunk data access, enhancing stability under load.
  - Simplified chunk section defaults and unified palette initialization for leaner memory use.
  - Deferred storage allocation until needed to reduce overhead.
  - Streamlined heightmap support by focusing on motion-blocking data only.
  - Optimized serialization/deserialization paths for chunks and biomes.
- Bug Fixes
  - Reduced chances of heightmap and palette inconsistencies during save/load.
- Chores
  - Cleaned up deprecated heightmap options and constructor variants to align behavior and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->